### PR TITLE
ref: integrate structlog.stdlib.add_log_level into processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ sentry_sdk.init()  # pass dsn in argument or via SENTRY_DSN env variable
 
 structlog.configure(
     processors=[
-        structlog.stdlib.add_log_level,  # required before SentryProcessor()
         SentryProcessor(level=logging.ERROR),
     ],
     logger_factory=...,
@@ -40,8 +39,7 @@ structlog.configure(
 log = structlog.get_logger()
 ```
 
-Do not forget to add the `structlog.stdlib.add_log_level` processor before
-`SentryProcessor`. The `SentryProcessor` class takes the following arguments:
+The `SentryProcessor` class takes the following arguments:
 
 - `level` - events of this or higher levels will be reported to Sentry,
   default is `WARNING`
@@ -84,7 +82,6 @@ You can set some or all of key/value pairs of structlog `event_dict` as sentry `
 ```python
 structlog.configure(
     processors=[
-        structlog.stdlib.add_log_level,
         SentryProcessor(level=logging.ERROR, tag_keys=["city", "timezone"]),
     ],...
 )
@@ -98,7 +95,6 @@ If you want to have all event data as tags, create the `SentryProcessor` with `t
 ```python
 structlog.configure(
     processors=[
-        structlog.stdlib.add_log_level,
         SentryProcessor(level=logging.ERROR, tag_keys="__all__"),
     ],...
 )
@@ -112,7 +108,6 @@ Sometimes you may want to skip this, specially when sending the `event_dict` as 
 ```python
 structlog.configure(
     processors=[
-        structlog.stdlib.add_log_level,
         SentryProcessor(level=logging.ERROR, as_extra=False, tag_keys="__all__"),
     ],...
 )
@@ -130,7 +125,6 @@ from structlog_sentry import SentryJsonProcessor
 structlog.configure(
     processors=[
         structlog.stdlib.add_logger_name,  # required before SentryJsonProcessor()
-        structlog.stdlib.add_log_level,
         SentryJsonProcessor(level=logging.ERROR, tag_keys="__all__"),
         structlog.processors.JSONRenderer()
     ],...

--- a/structlog_sentry/__init__.py
+++ b/structlog_sentry/__init__.py
@@ -7,6 +7,16 @@ from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.utils import event_from_exception
 
 
+def _get_level_from_method(method: str) -> str:
+    """
+    based on: https://www.structlog.org/en/stable/_modules/structlog/stdlib.html#add_log_level
+    """
+    if method == "warn":
+        # The stdlib has an alias
+        return "WARNING"
+    return method.upper()
+
+
 class SentryProcessor:
     """Sentry processor for structlog.
 
@@ -73,7 +83,7 @@ class SentryProcessor:
         """A middleware to process structlog `event_dict` and send it to Sentry."""
         self._original_event_dict = event_dict.copy()
         sentry_skip = event_dict.pop("sentry_skip", False)
-        do_log = getattr(logging, event_dict["level"].upper()) >= self.level
+        do_log = getattr(logging, _get_level_from_method(method)) >= self.level
 
         if sentry_skip or not self.active or not do_log:
             event_dict["sentry"] = "skipped"

--- a/structlog_sentry/__init__.py
+++ b/structlog_sentry/__init__.py
@@ -7,14 +7,11 @@ from sentry_sdk.integrations.logging import ignore_logger
 from sentry_sdk.utils import event_from_exception
 
 
-def _get_level_from_method(method: str) -> str:
+def _get_level_from_method(method: str) -> int:
     """
     based on: https://www.structlog.org/en/stable/_modules/structlog/stdlib.html#add_log_level
     """
-    if method == "warn":
-        # The stdlib has an alias
-        return "WARNING"
-    return method.upper()
+    return logging._nameToLevel[method.upper()]
 
 
 class SentryProcessor:
@@ -83,7 +80,7 @@ class SentryProcessor:
         """A middleware to process structlog `event_dict` and send it to Sentry."""
         self._original_event_dict = event_dict.copy()
         sentry_skip = event_dict.pop("sentry_skip", False)
-        do_log = getattr(logging, _get_level_from_method(method)) >= self.level
+        do_log = _get_level_from_method(method) >= self.level
 
         if sentry_skip or not self.active or not do_log:
             event_dict["sentry"] = "skipped"


### PR DESCRIPTION
The `add_log_level` function is so simple I think it might as well be
included so users don't need to remember to include the `add_log_level`
to use this processor.

Let me know what you think.