### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+---
+dist: bionic
+language: python
+
+install: pip install -U pip tox
+
+matrix:
+  fast_finish: true
+  include:
+    - name: Python 3.5 tests
+      python: '3.5'
+      script: tox -e py35
+
+    - name: Python 3.6 tests
+      python: '3.6'
+      script: tox -e py36
+
+    - name: Python 3.7 tests, linting
+      python: '3.7'
+      script: tox -e py37,lint
+
+branches:
+  only:
+    - master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # structlog-sentry
 
+[![Build Status](https://travis-ci.org/kiwicom/structlog-sentry.svg?branch=master)](https://travis-ci.org/kiwicom/structlog-sentry)
+
 | What          | Where                                         |
 | ------------- | --------------------------------------------- |
 | Documentation | <https://github.com/kiwicom/structlog-sentry> |


### PR DESCRIPTION
I thought this would be helpful to have so any PRs people have will automatically be tested. Thoughts?

This will require the owners of this org/repo to activate the Travis integration in travis-ci.org. It's free for open-source projects, FWIW