### PR TITLE
Bump version to 1.2.1 and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ except RequestException:
     log.error("request error", user_id=user_id)
 ```
 
+This will automatically collect `sys.exc_info()` along with the message, if you want
+to turn this behavior off, just pass `exc_info=False`.
+
 Logging calls with no `sys.exc_info()` are also automatically captured by Sentry:
 
 ```python

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md") as f:
 
 setup(
     name="structlog-sentry",
-    version="1.2.0",
+    version="1.2.1",
     url="https://github.com/kiwicom/structlog-sentry",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/structlog_sentry/__init__.py
+++ b/structlog_sentry/__init__.py
@@ -39,7 +39,7 @@ class SentryProcessor:
 
         :param event_dict: structlog event_dict
         """
-        exc_info = event_dict.pop("exc_info", sys.exc_info())
+        exc_info = event_dict.pop("exc_info", True)
         if exc_info is True:
             # logger.exeception() or logger.error(exc_info=True)
             exc_info = sys.exc_info()


### PR DESCRIPTION
- mention exc_info param in the docs
- simplify SentryProcessor._get_event_and_hint()