### PR TITLE
Copy `_original_event_dict` to event tags, extra

### DIFF
--- a/structlog_sentry/__init__.py
+++ b/structlog_sentry/__init__.py
@@ -56,9 +56,9 @@ class SentryProcessor:
             event["logger"] = event_dict["logger"]
 
         if self._as_extra:
-            event["extra"] = self._original_event_dict
+            event["extra"] = self._original_event_dict.copy()
         if self.tag_keys == "__all__":
-            event["tags"] = self._original_event_dict
+            event["tags"] = self._original_event_dict.copy()
         elif isinstance(self.tag_keys, list):
             event["tags"] = {
                 key: event_dict[key] for key in self.tag_keys if key in event_dict

--- a/test/test_sentry_processor.py
+++ b/test/test_sentry_processor.py
@@ -165,7 +165,12 @@ def test_sentry_log_no_extra(mocker, level):
 
 @pytest.mark.parametrize("level", ["debug", "info", "warning"])
 def test_sentry_log_all_as_tags(mocker, level):
-    m_capture_event = mocker.patch("structlog_sentry.capture_event")
+    @mocker.create_autospec
+    def modify_extra(event, **kwargs):
+        event["extra"].update({"foo": "bar"})
+        assert "foo" not in event["tags"]
+
+    m_capture_event = mocker.patch("structlog_sentry.capture_event", modify_extra)
 
     event_data = {"level": level, "event": level + " message"}
     sentry_event_data = event_data.copy()


### PR DESCRIPTION
Erroneous tag modification occurs as a consequence of `event["extra"]`
and `event["tags"]` pointing to the same reference and `event["extra"]`
being modified downstream (i.e., by Sentry integrations).

Fix #26