### PR TITLE
Add README note about valid Sentry tag values

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ structlog.configure(
 )
 ```
 
+**Note:** If you have non-simple values in your event data (such as dicts or lists), Sentry will
+not parse these as tags. Instead each will appear as an "invalid value" message on your events.
+Using `tag_keys="__all__"` can easily cause this, especially when integrating structlog
+and stdlib logging.
+
 ### Skip Extra
 
 By default `SentryProcessor` will send `event_dict` key/value pairs as extra info to the sentry.


### PR DESCRIPTION
Whilst installing structlog with a colleague, we use `tag_keys="__all__"` to try capture as much data as possible, but this just resulted in warnings on Sentry. I think a bit more caution around using `__all__` is appropriate.