### PR TITLE
Unpin sentry-sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ include = ["*.md", "*.toml", "*.txt", "*.yml", "*.yaml", ".coveragerc", "tox.ini
 
 [tool.poetry.dependencies]
 python = "^3.6"
-sentry-sdk = "^0.19.5"
+sentry-sdk = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.2"


### PR DESCRIPTION
The pin was added when coverting to poetry in c8fae6f48af44c4e1277abb9a999bd24fb79714b and is currently preventing us from upgrading to the latest sentry-sdk + structlog-sentry.

You could pin it to `"^0.20.0"` but then you'd need to update it every time Sentry releases a new minor version, which could be annoying.