### PR TITLE
Handle record and logger objects without name attr

### DIFF
--- a/structlog_sentry/__init__.py
+++ b/structlog_sentry/__init__.py
@@ -52,10 +52,10 @@ class SentryProcessor:
 
         if l_name:
             logger_name = l_name
-        elif record:
+        elif record and hasattr(record, "name"):
             logger_name = record.name
 
-        if not logger_name and logger:
+        if not logger_name and logger and hasattr(logger, "name"):
             logger_name = logger.name
 
         return logger_name


### PR DESCRIPTION
Bug encountered using:
```py
STRUCTLOG_PROCESSORS = [
    structlog.stdlib.add_log_level,
    SentryProcessor(level=logging.ERROR),
    structlog.stdlib.PositionalArgumentsFormatter(),
    structlog.processors.TimeStamper(fmt="%F %T", utc=True),
    structlog.processors.StackInfoRenderer(),
    structlog.processors.format_exc_info,
    structlog.dev.ConsoleRenderer(pad_event=60, colors=True, force_colors=True),
]

structlog.configure(
    wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
    processors=STRUCTLOG_PROCESSORS,
    cache_logger_on_first_use=True,
)
```
with traceback:
```pytb
...
  File "/usr/local/lib/python3.8/site-packages/structlog/_log_levels.py", line 118, in meth
    return self._proxy_to_logger(name, event, **kw)
  File "/usr/local/lib/python3.8/site-packages/structlog/_base.py", line 198, in _proxy_to_logger
    args, kw = self._process_event(method_name, event, event_kw)
  File "/usr/local/lib/python3.8/site-packages/structlog/_base.py", line 155, in _process_event
    event_dict = proc(self._logger, method_name, event_dict)
  File "/usr/local/lib/python3.8/site-packages/structlog/stdlib.py", line 667, in add_logger_name
    event_dict["logger"] = logger.name
AttributeError: 'PrintLogger' object has no attribute 'name'
```