### PR TITLE
Respect `with_locals` setting

### DIFF
--- a/structlog_sentry/__init__.py
+++ b/structlog_sentry/__init__.py
@@ -107,7 +107,12 @@ class SentryProcessor:
         has_exc_info = exc_info and exc_info != (None, None, None)
 
         if has_exc_info:
-            event, hint = event_from_exception(exc_info)
+            event, hint = event_from_exception(
+                exc_info,
+                client_options={
+                    "with_locals": self._get_hub().client.options.get("with_locals")
+                },
+            )
         else:
             event, hint = {}, {}
 


### PR DESCRIPTION
Hi!

This is a patch to use the `with_locals` setting from the Sentry client when creating an event.

[`with_locals`](https://docs.sentry.io/platforms/python/configuration/options/#with-locals) is a setting you can enable when initialising the Sentry SDK (

```python
sentry_sdk.init(
    with_locals=False,
    ...
)
```

) that can turn off local varibales being displayed with each stackframe.

[`event_from_exception`](https://github.com/getsentry/sentry-python/blob/8b1e8ce5f69265016ccc640b86ea1573749e23aa/sentry_sdk/utils.py#L739) uses it's own "`client_options`" which is used when [creating the frames](https://github.com/getsentry/sentry-python/blob/8b1e8ce5f69265016ccc640b86ea1573749e23aa/sentry_sdk/utils.py#L562-L570).