### PR TITLE
feat: Unify level and event_level with sentry-sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "structlog-sentry"
-version = "2.0.0b1"
+version = "2.0.0b2"
 description = "Sentry integration for structlog"
 authors = ["Kiwi.com platform <platform@kiwi.com>"]
 license = "MIT"

--- a/structlog_sentry/__init__.py
+++ b/structlog_sentry/__init__.py
@@ -34,8 +34,8 @@ class SentryProcessor:
 
     def __init__(
         self,
-        level: int = logging.WARNING,
-        breadcrumb_level: int = logging.INFO,
+        level: int = logging.INFO,
+        event_level: int = logging.WARNING,
         active: bool = True,
         as_context: bool = True,
         tag_keys: list[str] | str | None = None,
@@ -44,19 +44,23 @@ class SentryProcessor:
         hub: Hub | None = None,
     ) -> None:
         """
-        :param level: events of this or higher levels will be reported to Sentry.
-        :param breadcrumb_level: events of this or higher levels will be reported as
-            Sentry breadcrumbs.
-        :param active: a flag to make this processor enabled/disabled.
-        :param as_context: send `event_dict` as extra info to Sentry.
-        :param tag_keys: a list of keys. If any if these keys appear in `event_dict`,
+        :param level: Events of this or higher levels will be reported as
+            Sentry breadcrumbs. Dfault is :obj:`logging.INFO`.
+        :param event_level: Events of this or higher levels will be reported to Sentry
+            as events. Default is :obj:`logging.WARNING`.
+        :param active: A flag to make this processor enabled/disabled.
+        :param as_context: Send `event_dict` as extra info to Sentry.
+            Default is :obj:`True`.
+        :param tag_keys: A list of keys. If any if these keys appear in `event_dict`,
             the key and its corresponding value in `event_dict` will be used as Sentry
             event tags. use `"__all__"` to report all key/value pairs of event as tags.
-        :param ignore_loggers: a list of logger names to ignore any events from.
-        :param verbose: report the action taken by the logger in the `event_dict`.
+        :param ignore_loggers: A list of logger names to ignore any events from.
+        :param verbose: Report the action taken by the logger in the `event_dict`.
+            Default is :obj:`False`.
+        :param hub: Optionally specify :obj:`sentry_sdk.Hub`.
         """
+        self.event_level = event_level
         self.level = level
-        self.breadcrumb_level = breadcrumb_level
         self.active = active
         self.tag_keys = tag_keys
         self.verbose = verbose
@@ -169,10 +173,10 @@ class SentryProcessor:
         if self.active and not sentry_skip and self._can_record(logger, event_dict):
             level = getattr(logging, event_dict["level"].upper())
 
-            if level >= self.level:
+            if level >= self.event_level:
                 self._handle_event(event_dict)
 
-            if level >= self.breadcrumb_level:
+            if level >= self.level:
                 self._handle_breadcrumb(event_dict)
 
         if self.verbose:

--- a/test/test_sentry_processor.py
+++ b/test/test_sentry_processor.py
@@ -60,7 +60,7 @@ def test_sentry_sent():
 def test_sentry_log(sentry_events, level):
     event_data = {"level": level, "event": level + " message"}
 
-    processor = SentryProcessor(level=getattr(logging, level.upper()))
+    processor = SentryProcessor(event_level=getattr(logging, level.upper()))
     processor(None, None, event_data)
 
     assert_event_dict(event_data, sentry_events)
@@ -68,7 +68,7 @@ def test_sentry_log(sentry_events, level):
 
 @pytest.mark.parametrize("level", ["debug", "info", "warning"])
 def test_sentry_log_only_errors(sentry_events, level):
-    processor_only_errors = SentryProcessor(level=logging.ERROR, verbose=True)
+    processor_only_errors = SentryProcessor(event_level=logging.ERROR, verbose=True)
     event_dict = processor_only_errors(
         None, None, {"level": level, "event": level + " message"}
     )
@@ -82,7 +82,7 @@ def test_sentry_log_failure(sentry_events, level):
     'exception' information after processing
     """
     event_data = {"level": level, "event": level + " message"}
-    processor = SentryProcessor(level=getattr(logging, level.upper()))
+    processor = SentryProcessor(event_level=getattr(logging, level.upper()))
     try:
         1 / 0
     except ZeroDivisionError:
@@ -99,7 +99,7 @@ def test_sentry_log_failure_exc_info_true(sentry_events, level):
     are used.
     """
     event_data = {"level": level, "event": level + " message", "exc_info": True}
-    processor = SentryProcessor(level=getattr(logging, level.upper()))
+    processor = SentryProcessor(event_level=getattr(logging, level.upper()))
     try:
         1 / 0
     except ZeroDivisionError:
@@ -149,7 +149,7 @@ def test_sentry_log_leave_exc_info_untouched(sentry_events):
 def test_sentry_log_all_as_tags(sentry_events, level):
     event_data = {"level": level, "event": level + " message"}
     processor = SentryProcessor(
-        level=getattr(logging, level.upper()), tag_keys="__all__"
+        event_level=getattr(logging, level.upper()), tag_keys="__all__"
     )
     processor(None, None, event_data)
 
@@ -170,7 +170,7 @@ def test_sentry_log_specific_keys_as_tags(sentry_events, level):
     }
     tag_keys = ["info1", "required", "some non existing key"]
     processor = SentryProcessor(
-        level=getattr(logging, level.upper()), tag_keys=tag_keys
+        event_level=getattr(logging, level.upper()), tag_keys=tag_keys
     )
     processor(None, None, event_data)
 
@@ -219,7 +219,7 @@ def test_sentry_ignore_logger(sentry_events, level):
     blacklisted_logger = MockLogger("test.blacklisted")
     whitelisted_logger = MockLogger("test.whitelisted")
     processor = SentryProcessor(
-        level=getattr(logging, level.upper()),
+        event_level=getattr(logging, level.upper()),
         ignore_loggers=["test.blacklisted"],
         verbose=True,
     )


### PR DESCRIPTION
- BREAKING CHANGE: SentryProcessor level argument renamed to event_level
- SentryProcessor breadcrumb_level argument renamed to level