### PR TITLE
docs: replace level=logging.ERROR with event_level=logging.ERROR in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ structlog.configure(
     processors=[
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
-        SentryProcessor(level=logging.ERROR, tag_keys=["city", "timezone"]),
+        SentryProcessor(event_level=logging.ERROR, tag_keys=["city", "timezone"]),
     ],...
 )
 
@@ -128,7 +128,7 @@ structlog.configure(
     processors=[
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
-        SentryProcessor(level=logging.ERROR, tag_keys="__all__"),
+        SentryProcessor(event_level=logging.ERROR, tag_keys="__all__"),
     ],...
 )
 ```
@@ -143,7 +143,7 @@ structlog.configure(
     processors=[
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
-        SentryProcessor(level=logging.ERROR, as_context=False, tag_keys="__all__"),
+        SentryProcessor(event_level=logging.ERROR, as_context=False, tag_keys="__all__"),
     ],...
 )
 ```
@@ -158,7 +158,7 @@ structlog.configure(
     processors=[
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
-        SentryProcessor(level=logging.ERROR, ignore_loggers=["some.logger"]),
+        SentryProcessor(event_level=logging.ERROR, ignore_loggers=["some.logger"]),
     ],...
 )
 ```


### PR DESCRIPTION
As `event_level` actually filters events, while `level` only impacts breadcrumbs.

The doc is quite clear about the functionality, but we actually tripped on this, probably because we just copy/pasted one of the examples.
"Fixing" the examples might save others from tripping as we did :)