### PR TITLE
fix: update min supported version of the sentry sdk

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -359,4 +359,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "980182b2f589addc75338e72d08e05b1c77fd6f0d7649adbaec77dacc4705399"
+content-hash = "bdf69134a6f36ca393e1e40e6123f880085705ae3fa4c49a53046949a40859c5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ include = ["*.md", "*.toml", "*.txt", "*.yml", "*.yaml", ".coveragerc", "tox.ini
 
 [tool.poetry.dependencies]
 python = "^3.7"
-sentry-sdk = "^2.0"
+sentry-sdk = "^2.15.0"
 structlog = "*"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
- get_isolation_scope needs 2.12 (not 2.0)
- this breadcrumb sorting issue/crash is fixed in 2.15 https://github.com/getsentry/sentry-python/issues/3508#issuecomment-2340097768